### PR TITLE
Updates the  terminology to match upcoming WCAM v3.5.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,8 @@
 *** WooCommerce API Manager PHP Library for Plugins and Themes Changelog ***
 
+2025.05.22 - version 2.11.0
+* New: Updates terminology in labels and text matching the latest API Manager version
+
 2025.03.17 - version 2.10.0
 * Tweak: Reduce the number of calls to the API server when loading activation settings pages
 * Tweak: Allow passing the parent product ID to the client constructor (breaking change)

--- a/examples/wc-api-manager-example.php
+++ b/examples/wc-api-manager-example.php
@@ -1,15 +1,15 @@
 <?php
 /**
- * Plugin Name: WooCommerce API Manager PHP Library for Plugins and Themes Example
+ * Plugin Name: Kestrel API Manager for WooCommerce PHP Library for Plugins and Themes Example
  * Plugin URI: https://kestrelwp.com/product/woocommerce-api-manager-php-library-for-plugins-and-themes/
  * Description: Drop the wc-am-client.php library into a plugin or theme, and use the example code below this comment block following carefully the instructions and the documentation.
- * Version: 2.10.0
+ * Version: 2.11.0
  * Author: Kestrel
  * Author URI: https://kestrelwp.com
  *
  * Copyright: (c) 2023-2025 Kestrel [hey@kestrelwp.com]
  *
- * @package     WooCommerce API Manager Library for plugin or theme
+ * @package     API Manager for WooCommerce PHP Library for Plugins and Themes Example
  * @author      Kestrel
  * @category    Plugin/Theme/library
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
@@ -25,7 +25,7 @@ defined( 'ABSPATH' ) || exit;
  */
 
 // Load the WC_AM_Client client class if it exists.
-if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
+if ( ! class_exists( 'WC_AM_Client_2_11_0' ) ) {
 	/**
 	 * This library does not use Composer autoloading to support a wider range of implementations.
 	 *
@@ -37,7 +37,7 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 }
 
 // Instantiate the WC_AM_Client class object if the WC_AM_Client class is loaded.
-if ( class_exists( 'WC_AM_Client_2_10_0' ) ) {
+if ( class_exists( 'WC_AM_Client_2_11_0' ) ) {
 	/**
 	 * This file is only an example that includes a plugin header, and this code is used to instantiate the client object.
 	 *
@@ -69,7 +69,7 @@ if ( class_exists( 'WC_AM_Client_2_10_0' ) ) {
 	 *
 	 * @NOTE Replace the dummy values with your own.
 	 */
-	$wcam_lib = new WC_AM_Client_2_10_0( __FILE__, 123, null, '1.0', 'theme', 'https://example.org/example-theme', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
+	$wcam_lib = new WC_AM_Client_2_11_0( __FILE__, 123, null, '1.0', 'theme', 'https://example.org/example-theme', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
 
 	/**
 	 * Plugin example (default menu).
@@ -80,13 +80,13 @@ if ( class_exists( 'WC_AM_Client_2_10_0' ) ) {
 	 */
 
 	// If the Product ID is not set the customer will see a form field when activating the API Key that requires the Product ID along with a form field for the API Key.
-	$wcam_lib = new WC_AM_Client_2_10_0( __FILE__, '', null, '1.2.3', 'plugin', 'https://example.org/example-plugin', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
+	$wcam_lib = new WC_AM_Client_2_11_0( __FILE__, '', null, '1.2.3', 'plugin', 'https://example.org/example-plugin', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
 
 	// Setting the Product ID below will eliminate the required form field for the customer to enter the Product ID, so the customer will only be required to enter the API Key.
-	$wcam_lib = new WC_AM_Client_2_10_0( __FILE__, 456, null, '1.2.3', 'plugin', 'https://example.org/example-plugin', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
+	$wcam_lib = new WC_AM_Client_2_11_0( __FILE__, 456, null, '1.2.3', 'plugin', 'https://example.org/example-plugin', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
 
 	// If you offer the product as a variable product where the customer can switch to another product with a different Product ID, then do not set the Product ID here, but you may pass a product parent ID instead (generally not recommended unless you are using subscription switches and not setting a product ID or letting the customer enter it).
-	$wcam_lib = new WC_AM_Client_2_10_0( __FILE__, null, 789, '1.2.3', 'plugin', 'https://example.org/example-plugin', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
+	$wcam_lib = new WC_AM_Client_2_11_0( __FILE__, null, 789, '1.2.3', 'plugin', 'https://example.org/example-plugin', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
 
 	/**
 	 * Custom top level or top level submenu.
@@ -99,7 +99,7 @@ if ( class_exists( 'WC_AM_Client_2_10_0' ) ) {
 	 * @see add_options_page( $page_title, $menu_title, $capability, $menu_slug, $callback = '', $position = null );
 	 * @see add_menu_page( $page_title, $menu_title, $capability, $menu_slug, $callback = '', $icon_url = '', $position = null );
 	 *
-	 * Then pass the custom menu settings as an array to the WC_AM_Client_2_10_0 class as shown in the example below.
+	 * Then pass the custom menu settings as an array to the WC_AM_Client_2_11_0 class as shown in the example below.
 	 */
 
 	$wcam_lib_custom_menu = array(
@@ -109,13 +109,13 @@ if ( class_exists( 'WC_AM_Client_2_10_0' ) ) {
 		'menu_title'  => __( 'Example API Key', 'example-textdomain' ),
 	);
 
-	$wcam_lib = new WC_AM_Client_2_10_0( __FILE__, 123, null, '1.2.3', 'plugin', 'https://example.org/example-plugin', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain', $wcam_lib_custom_menu );
+	$wcam_lib = new WC_AM_Client_2_11_0( __FILE__, 123, null, '1.2.3', 'plugin', 'https://example.org/example-plugin', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain', $wcam_lib_custom_menu );
 
 	/**
 	 * Suppress the inactive notice.
 	 *
-	 * When your plugin or theme is activated, the WC_AM_Client_2_10_0 class will display a notice in the admin area if the plugin or theme has not been activated.
+	 * When your plugin or theme is activated, the WC_AM_Client_2_11_0 class will display a notice in the admin area if the plugin or theme has not been activated.
 	 * You can disable this by setting the last argument passed to the client constructor to false.
 	 */
-	$wcam_lib = new WC_AM_Client_2_10_0( __FILE__, 123, null, '1.2.3', 'plugin', 'https://example.org/example-plugin', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain', null, false );
+	$wcam_lib = new WC_AM_Client_2_11_0( __FILE__, 123, null, '1.2.3', 'plugin', 'https://example.org/example-plugin', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain', null, false );
 }

--- a/wc-am-client.php
+++ b/wc-am-client.php
@@ -219,10 +219,10 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 				$this->wc_am_activation_tab_key          = $this->data_key . '_dashboard';
 				$this->wc_am_deactivation_tab_key        = $this->data_key . '_deactivation';
 				$this->wc_am_auto_update_key             = $this->data_key . '_auto_update';
-				$this->wc_am_settings_title              = sprintf( __( '%s', $this->text_domain ), ! empty( $this->menu['page_title'] ) ? $this->menu['page_title'] : $this->software_title . ' API Key Activation', $this->text_domain ); // phpcs:ignore
-				$this->wc_am_settings_menu_title         = sprintf( __( '%s', $this->text_domain ), ! empty( $this->menu['menu_title'] ) ? $this->menu['menu_title'] : $this->software_title . ' Activation', $this->text_domain ); // phpcs:ignore
-				$this->wc_am_menu_tab_activation_title   = esc_html__( 'API Key Activation', $this->text_domain ); // phpcs:ignore
-				$this->wc_am_menu_tab_deactivation_title = esc_html__( 'API Key Deactivation', $this->text_domain ); // phpcs:ignore
+				$this->wc_am_settings_title              = sprintf( __( '%s', $this->text_domain ), ! empty( $this->menu['page_title'] ) ? $this->menu['page_title'] : $this->software_title . ' license key activation', $this->text_domain ); // phpcs:ignore
+				$this->wc_am_settings_menu_title         = sprintf( __( '%s', $this->text_domain ), ! empty( $this->menu['menu_title'] ) ? $this->menu['menu_title'] : $this->software_title . ' activation', $this->text_domain ); // phpcs:ignore
+				$this->wc_am_menu_tab_activation_title   = esc_html__( 'License key activation', $this->text_domain ); // phpcs:ignore
+				$this->wc_am_menu_tab_deactivation_title = esc_html__( 'License key deactivation', $this->text_domain ); // phpcs:ignore
 
 				/**
 				 * Set all software update data here.
@@ -591,7 +591,7 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 				}
 				?>
 				<div class="notice notice-error">
-					<p><?php printf( __( 'The <strong>%1$s</strong> API Key has not been activated, so the %2$s is inactive! %3$sClick here%4$s to activate <strong>%5$s</strong>.', $this->text_domain ), esc_attr( $this->software_title ), esc_attr( $this->plugin_or_theme ), '<a href="' . esc_url( admin_url( 'options-general.php?page=' . $this->wc_am_activation_tab_key ) ) . '">', '</a>', esc_attr( $this->software_title ) ); // phpcs:ignore ?></p>
+					<p><?php printf( __( 'The <strong>%1$s</strong> license key has not been activated, so %2$s is inactive! %3$sClick here%4$s to activate <strong>%5$s</strong>.', $this->text_domain ), esc_attr( $this->software_title ), esc_attr( $this->plugin_or_theme ), '<a href="' . esc_url( admin_url( 'options-general.php?page=' . $this->wc_am_activation_tab_key ) ) . '">', '</a>', esc_attr( $this->software_title ) ); // phpcs:ignore ?></p>
 				</div>
 				<?php
 			}
@@ -650,11 +650,11 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 						if ( $tab === $this->wc_am_activation_tab_key ) {
 							settings_fields( $this->data_key );
 							do_settings_sections( $this->wc_am_activation_tab_key );
-							submit_button( esc_html__( 'Save Changes', $this->text_domain ) ); // phpcs:ignore
+							submit_button( esc_html__( 'Save changes', $this->text_domain ) ); // phpcs:ignore
 						} else {
 							settings_fields( $this->wc_am_deactivate_checkbox_key );
 							do_settings_sections( $this->wc_am_deactivation_tab_key );
-							submit_button( esc_html__( 'Save Changes', $this->text_domain ) ); // phpcs:ignore
+							submit_button( esc_html__( 'Save changes', $this->text_domain ) ); // phpcs:ignore
 						}
 						?>
 					</div>
@@ -674,21 +674,21 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 			register_setting( $this->data_key, $this->data_key, array( $this, 'validate_options' ) );
 
 			// API Key.
-			add_settings_section( $this->wc_am_api_key_key, esc_html__( 'API Key Activation', $this->text_domain ), array( $this, 'wc_am_api_key_text' ), $this->wc_am_activation_tab_key ); // phpcs:ignore
-			add_settings_field( $this->wc_am_api_key_key, esc_html__( 'API Key', $this->text_domain ), array( $this, 'wc_am_api_key_field' ), $this->wc_am_activation_tab_key, $this->wc_am_api_key_key ); // phpcs:ignore
+			add_settings_section( $this->wc_am_api_key_key, esc_html__( 'License key activation', $this->text_domain ), array( $this, 'wc_am_api_key_text' ), $this->wc_am_activation_tab_key ); // phpcs:ignore
+			add_settings_field( $this->wc_am_api_key_key, esc_html__( 'License key', $this->text_domain ), array( $this, 'wc_am_api_key_field' ), $this->wc_am_activation_tab_key, $this->wc_am_api_key_key ); // phpcs:ignore
 
 			if ( $this->no_product_id ) {
 				add_settings_field( 'product_id', esc_html__( 'Product ID', $this->text_domain ), array( $this, 'wc_am_product_id_field' ), $this->wc_am_activation_tab_key, $this->wc_am_api_key_key ); // phpcs:ignore
 			}
 
-			add_settings_field( 'status', esc_html__( 'API Key Status', $this->text_domain ), array( $this, 'wc_am_api_key_status' ), $this->wc_am_activation_tab_key, $this->wc_am_api_key_key ); // phpcs:ignore
-			add_settings_field( 'info', esc_html__( 'Activation Info', $this->text_domain ), array( $this, 'wc_am_activation_info' ), $this->wc_am_activation_tab_key, $this->wc_am_api_key_key ); // phpcs:ignore
+			add_settings_field( 'status', esc_html__( 'License key status', $this->text_domain ), array( $this, 'wc_am_api_key_status' ), $this->wc_am_activation_tab_key, $this->wc_am_api_key_key ); // phpcs:ignore
+			add_settings_field( 'info', esc_html__( 'Activation info', $this->text_domain ), array( $this, 'wc_am_activation_info' ), $this->wc_am_activation_tab_key, $this->wc_am_api_key_key ); // phpcs:ignore
 
 			// Activation settings.
 			register_setting( $this->wc_am_deactivate_checkbox_key, $this->wc_am_deactivate_checkbox_key, array( $this, 'wc_am_license_key_deactivation' ) );
 
-			add_settings_section( 'deactivate_button', esc_html__( 'API Deactivation', $this->text_domain ), array( $this, 'wc_am_deactivate_text' ), $this->wc_am_deactivation_tab_key ); //  phpcs:ignore
-			add_settings_field( 'deactivate_button', esc_html__( 'Deactivate API Key', $this->text_domain ), array( $this, 'wc_am_deactivate_textarea' ), $this->wc_am_deactivation_tab_key, 'deactivate_button' ); // phpcs:ignore
+			add_settings_section( 'deactivate_button', esc_html__( 'License deactivation', $this->text_domain ), array( $this, 'wc_am_deactivate_text' ), $this->wc_am_deactivation_tab_key ); //  phpcs:ignore
+			add_settings_field( 'deactivate_button', esc_html__( 'Deactivate license key', $this->text_domain ), array( $this, 'wc_am_deactivate_textarea' ), $this->wc_am_deactivation_tab_key, 'deactivate_button' ); // phpcs:ignore
 		}
 
 		/**
@@ -786,9 +786,9 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 				if ( ! empty( $live_status ) && isset( $live_status['status_check'] ) && $live_status['success'] === 'active' ) {
 					echo esc_html( 'Activations purchased: ' . $live_status['data']['total_activations_purchased'], $this->text_domain ); // phpcs:ignore
 					echo $line_break; // phpcs:ignore
-					echo esc_html( 'Total Activations: ' . $live_status['data']['total_activations'], $this->text_domain ); // phpcs:ignore
+					echo esc_html( 'Total activations: ' . $live_status['data']['total_activations'], $this->text_domain ); // phpcs:ignore
 					echo $line_break; // phpcs:ignore
-					echo esc_html( 'Activations Remaining: ' . $live_status['data']['activations_remaining'], $this->text_domain ); // phpcs:ignore
+					echo esc_html( 'Activations remaining: ' . $live_status['data']['activations_remaining'], $this->text_domain ); // phpcs:ignore
 				} elseif ( ! empty( $result_success ) ) {
 					echo esc_html( $result_success );
 				} else {
@@ -798,9 +798,9 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 
 				echo esc_html( 'Activations purchased: ' . $live_status['data']['total_activations_purchased'], $this->text_domain ); // phpcs:ignore
 				echo $line_break; // phpcs:ignore
-				echo esc_html( 'Total Activations: ' . $live_status['data']['total_activations'], $this->text_domain ); // phpcs:ignore
+				echo esc_html( 'Total activations: ' . $live_status['data']['total_activations'], $this->text_domain ); // phpcs:ignore
 				echo $line_break; // phpcs:ignore
-				echo esc_html( 'Activations Remaining: ' . $live_status['data']['activations_remaining'], $this->text_domain ); // phpcs:ignore
+				echo esc_html( 'Activations remaining: ' . $live_status['data']['activations_remaining'], $this->text_domain ); // phpcs:ignore
 			} elseif ( ! $this->get_api_key_status() && ! empty( $result_error ) ) {
 				echo esc_html__( 'Previous activation attempt errors:', $this->text_domain ); // phpcs:ignore
 				echo $line_break; // phpcs:ignore
@@ -915,7 +915,7 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 
 						if ( $activate_results === false && ! empty( $this->data ) && ! empty( $this->wc_am_activated_key ) ) {
 
-							add_settings_error( 'api_key_check_text', 'api_key_check_error', esc_html__( 'Connection failed to the License Key API server. See the Activation Error section below for details. There may be a problem on your server preventing outgoing requests, or the store is blocking your request to activate the plugin/theme.', $this->text_domain ), 'error' ); // phpcs:ignore
+							add_settings_error( 'api_key_check_text', 'api_key_check_error', esc_html__( 'Connection failed to the licensing server. See the "Activation error" section below for details. There may be a problem on your server preventing outgoing requests, or the store is blocking your request to activate the plugin/theme.', $this->text_domain ), 'error' ); // phpcs:ignore
 
 							update_option( $this->wc_am_activated_key, 'Deactivated' );
 						}
@@ -925,7 +925,7 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 							update_option( $this->wc_am_activated_key, 'Deactivated' );
 						}
 					} else {
-						add_settings_error( 'not_activated_empty_response_text', 'not_activated_empty_response_error', esc_html__( 'The API Key activation could not be completed due to an error on the store server or your server. See the Activation Error section below for details. The activation results were empty.', $this->text_domain ), 'updated' ); // phpcs:ignore
+						add_settings_error( 'not_activated_empty_response_text', 'not_activated_empty_response_error', esc_html__( 'The license key activation could not be completed due to an error on the store server or your server. See the "Activation error" section below for details. The activation results were empty.', $this->text_domain ), 'updated' ); // phpcs:ignore
 					}
 				}
 			}
@@ -992,7 +992,7 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 
 							update_option( $this->wc_am_activated_key, 'Deactivated' );
 
-							add_settings_error( 'wc_am_deactivate_text', 'deactivate_msg', esc_html__( 'API Key deactivated. ', $this->text_domain ) . esc_attr( "{$activate_results['activations_remaining']}." ), 'updated' ); // phpcs:ignore
+							add_settings_error( 'wc_am_deactivate_text', 'deactivate_msg', esc_html__( 'License key deactivated. ', $this->text_domain ) . esc_attr( "{$activate_results['activations_remaining']}." ), 'updated' ); // phpcs:ignore
 						}
 
 						return $options;
@@ -1006,7 +1006,7 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 					}
 				} else {
 
-					add_settings_error( 'not_deactivated_empty_response_text', 'not_deactivated_empty_response_error', esc_html__( 'The API Key activation could not be completed due to an unknown error possibly on the store server The activation results were empty.', $this->text_domain ), 'updated' ); // phpcs:ignore
+					add_settings_error( 'not_deactivated_empty_response_text', 'not_deactivated_empty_response_error', esc_html__( 'The license key activation could not be completed due to an unknown error possibly on the store server The activation results were empty.', $this->text_domain ), 'updated' ); // phpcs:ignore
 				}
 			}
 
@@ -1048,7 +1048,7 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 			echo checked( get_option( $this->wc_am_deactivate_checkbox_key ), 'on' );
 			echo '/>';
 			?>
-			<span class="description"><?php esc_html_e( 'Deactivates an API Key so it can be used on another blog.', $this->text_domain ); // phpcs:ignore ?></span>
+			<span class="description"><?php esc_html_e( 'Deactivates a license key so it can be used on another site.', $this->text_domain ); // phpcs:ignore ?></span>
 			<?php
 		}
 
@@ -1071,7 +1071,7 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 		public function activate( $args ) {
 
 			if ( empty( $args ) ) {
-				add_settings_error( 'not_activated_text', 'not_activated_error', esc_html__( 'The API Key is missing from the deactivation request.', $this->text_domain ), 'updated' ); // phpcs:ignore
+				add_settings_error( 'not_activated_text', 'not_activated_error', esc_html__( 'The license key is missing from the deactivation request.', $this->text_domain ), 'updated' ); // phpcs:ignore
 
 				return '';
 			}
@@ -1114,7 +1114,7 @@ if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
 		public function deactivate( $args ) {
 
 			if ( empty( $args ) ) {
-				add_settings_error( 'not_deactivated_text', 'not_deactivated_error', esc_html__( 'The API Key is missing from the deactivation request.', $this->text_domain ), 'updated' ); // phpcs:ignore
+				add_settings_error( 'not_deactivated_text', 'not_deactivated_error', esc_html__( 'The license key is missing from the deactivation request.', $this->text_domain ), 'updated' ); // phpcs:ignore
 
 				return '';
 			}

--- a/wc-am-client.php
+++ b/wc-am-client.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * WooCommerce API Manager PHP Client Library
+ * Kestrel API Manager for WooCommerce PHP Client Library
  *
- * Designed to be used with WooCommerce API Manager 2.x, and dropped into a WordPress plugin or theme.
+ * Designed to be used with Kestrel API Manager for WooCommerce, and dropped into a WordPress plugin or theme.
  *
  * This source file is subject to the GNU General Public License v3.0
  * that is bundled with this plugin in the file license.txt
@@ -12,7 +12,7 @@
  * please review our developer documentation at https://kestrelwp.com/docs/woocommerce-api-manager-php-library-for-plugins-and-themes-documentation/
  * and join our developer program at https://kestrelwp.com/developers
  *
- * @version     2.10.0
+ * @version     2.11.0
  * @author      Kestrel
  * @copyright   Copyright (c) 2013-2025 Kestrel
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
@@ -21,11 +21,13 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( 'WC_AM_Client_2_10_0' ) ) {
+if ( ! class_exists( 'WC_AM_Client_2_11_0' ) ) {
 	/**
-	 * WooCommerce API Manager client class.
+	 * API Manager for WooCommerce client class.
+	 *
+	 * @since 1.0.0
 	 */
-	class WC_AM_Client_2_10_0 {
+	class WC_AM_Client_2_11_0 {
 
 		/** @var string API URL. */
 		private $api_url = '';


### PR DESCRIPTION
With https://github.com/kestrelwp/api-manager-for-woocommerce/pull/32 and  https://github.com/kestrelwp/api-manager-for-woocommerce/pull/31 we are making some presentational updates in the UI, mainly:

* API key => License key
* Master API key => Master license key
* Order product API key => Product license key
* API => Licensing
* API resource => Licensing resource
* API customers => Licenses (this seems only used in the admin screen header)

these changes should be reflected in the client library