### PR TITLE
Release: v2.12.0

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,6 @@
 
 2026.nn.nn - version 2.12.0
 * Feature: Allow requesting updates while the client library runs on a staging or local development environment
-* Misc: Send the site URL as part of a request payload
 
 2025.06.09 - version 2.11.1
 * Fix: Correctly output HTML links in API error messages

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,7 +1,8 @@
 *** WooCommerce API Manager PHP Library for Plugins and Themes Changelog ***
 
 2026.nn.nn - version 2.12.0
-* Feature: Allow requesting updates while the client library runs on a staging or local development environment
+* Tweak: Do not display the license activation prompt on staging sites
+* Misc: Ensure to always send the current site URL to improve handling of staging site activations and updates with the latest API Manager server versions
 
 2025.06.09 - version 2.11.1
 * Fix: Correctly output HTML links in API error messages

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
 *** WooCommerce API Manager PHP Library for Plugins and Themes Changelog ***
 
+2026.nn.nn - version 2.12.0
+* Feature: Allow requesting updates while the client library runs on a staging or local development environment
+* Misc: Send the site URL as part of a request payload
+
 2025.06.09 - version 2.11.1
 * Fix: Correctly output HTML links in API error messages
 * Fix: Improve translatable activation information output

--- a/composer.lock
+++ b/composer.lock
@@ -409,5 +409,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/examples/wc-api-manager-example.php
+++ b/examples/wc-api-manager-example.php
@@ -3,11 +3,11 @@
  * Plugin Name: Kestrel API Manager for WooCommerce PHP Library for Plugins and Themes Example
  * Plugin URI: https://kestrelwp.com/product/woocommerce-api-manager-php-library-for-plugins-and-themes/
  * Description: Drop the wc-am-client.php library into a plugin or theme, and use the example code below this comment block following carefully the instructions and the documentation.
- * Version: 2.11.1
+ * Version: 2.12.0
  * Author: Kestrel
  * Author URI: https://kestrelwp.com
  *
- * Copyright: (c) 2023-2025 Kestrel [hey@kestrelwp.com]
+ * Copyright: (c) 2023-2026 Kestrel [hey@kestrelwp.com]
  *
  * @package     API Manager for WooCommerce PHP Library for Plugins and Themes Example
  * @author      Kestrel
@@ -26,7 +26,7 @@ defined( 'ABSPATH' ) || exit;
  */
 
 // Load the WC_AM_Client client class if it exists.
-if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
+if ( ! class_exists( 'WC_AM_Client_2_12_0' ) ) {
 	/**
 	 * This library does not use Composer autoloading to support a wider range of implementations.
 	 *
@@ -38,7 +38,7 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 }
 
 // Instantiate the WC_AM_Client class object if the WC_AM_Client class is loaded.
-if ( class_exists( 'WC_AM_Client_2_11_1' ) ) {
+if ( class_exists( 'WC_AM_Client_2_12_0' ) ) {
 	/**
 	 * This file is only an example that includes a plugin header, and this code is used to instantiate the client object.
 	 *
@@ -70,7 +70,7 @@ if ( class_exists( 'WC_AM_Client_2_11_1' ) ) {
 	 *
 	 * @NOTE Replace the dummy values with your own.
 	 */
-	$wcam_lib = new WC_AM_Client_2_11_1( __FILE__, 123, null, '1.0.0', 'theme', 'https://example.org/', __( 'Example WordPress Theme', 'example-textdomain' ), 'example-textdomain' );
+	$wcam_lib = new WC_AM_Client_2_12_0( __FILE__, 123, null, '1.0.0', 'theme', 'https://example.org/', __( 'Example WordPress Theme', 'example-textdomain' ), 'example-textdomain' );
 
 	/**
 	 * Plugin example (default menu).
@@ -81,13 +81,13 @@ if ( class_exists( 'WC_AM_Client_2_11_1' ) ) {
 	 */
 
 	// If the Product ID is not set the customer will see a form field when activating the API Key that requires the Product ID along with a form field for the API Key.
-	$wcam_lib = new WC_AM_Client_2_11_1( __FILE__, '', null, '1.2.3', 'plugin', 'https://example.org/', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
+	$wcam_lib = new WC_AM_Client_2_12_0( __FILE__, '', null, '1.2.3', 'plugin', 'https://example.org/', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
 
 	// Setting the Product ID below will eliminate the required form field for the customer to enter the Product ID, so the customer will only be required to enter the API Key.
-	$wcam_lib = new WC_AM_Client_2_11_1( __FILE__, 456, null, '1.2.3', 'plugin', 'https://example.org/', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
+	$wcam_lib = new WC_AM_Client_2_12_0( __FILE__, 456, null, '1.2.3', 'plugin', 'https://example.org/', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
 
 	// If you offer the product as a variable product where the customer can switch to another product with a different Product ID, then do not set the Product ID here, but you may pass a product parent ID instead (generally not recommended unless you are using subscription switches and not setting a product ID or letting the customer enter it).
-	$wcam_lib = new WC_AM_Client_2_11_1( __FILE__, null, 789, '1.2.3', 'plugin', 'https://example.org/', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
+	$wcam_lib = new WC_AM_Client_2_12_0( __FILE__, null, 789, '1.2.3', 'plugin', 'https://example.org/', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain' );
 
 	/**
 	 * Custom top level or top level submenu.
@@ -100,7 +100,7 @@ if ( class_exists( 'WC_AM_Client_2_11_1' ) ) {
 	 * @see add_options_page( $page_title, $menu_title, $capability, $menu_slug, $callback = '', $position = null );
 	 * @see add_menu_page( $page_title, $menu_title, $capability, $menu_slug, $callback = '', $icon_url = '', $position = null );
 	 *
-	 * Then pass the custom menu settings as an array to the WC_AM_Client_2_11_1 class as shown in the example below.
+	 * Then pass the custom menu settings as an array to the WC_AM_Client_2_12_0 class as shown in the example below.
 	 */
 
 	$wcam_lib_custom_menu = array(
@@ -110,13 +110,13 @@ if ( class_exists( 'WC_AM_Client_2_11_1' ) ) {
 		'menu_title'  => __( 'Example API Key', 'example-textdomain' ),
 	);
 
-	$wcam_lib = new WC_AM_Client_2_11_1( __FILE__, 123, null, '1.2.3', 'plugin', 'https://example.org/', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain', $wcam_lib_custom_menu );
+	$wcam_lib = new WC_AM_Client_2_12_0( __FILE__, 123, null, '1.2.3', 'plugin', 'https://example.org/', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain', $wcam_lib_custom_menu );
 
 	/**
 	 * Suppress the inactive notice.
 	 *
-	 * When your plugin or theme is activated, the WC_AM_Client_2_11_1 class will display a notice in the admin area if the plugin or theme has not been activated.
+	 * When your plugin or theme is activated, the WC_AM_Client_2_12_0 class will display a notice in the admin area if the plugin or theme has not been activated.
 	 * You can disable this by setting the last argument passed to the client constructor to false.
 	 */
-	$wcam_lib = new WC_AM_Client_2_11_1( __FILE__, 123, null, '1.2.3', 'plugin', 'https://example.org/', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain', null, false );
+	$wcam_lib = new WC_AM_Client_2_12_0( __FILE__, 123, null, '1.2.3', 'plugin', 'https://example.org/', __( 'Example WordPress Plugin', 'example-textdomain' ), 'example-textdomain', null, false );
 }

--- a/license.txt
+++ b/license.txt
@@ -1,7 +1,7 @@
 
 API Manager for WooCommerce PHP client library
 
-Copyright © Kestrel Commerce LLC
+Copyright © 2013-2026 Kestrel Commerce LLC
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/wc-am-client.php
+++ b/wc-am-client.php
@@ -698,12 +698,12 @@ if ( ! class_exists( 'WC_AM_Client_2_12_0' ) ) {
 				if ( ! current_user_can( 'manage_options' ) ) {
 					return;
 				}
-				// Do not show activation notice on staging/development sites.
-				if ( $this->is_staging() ) {
-					return;
-				}
 				// phpcs:ignore
 				if ( isset( $_GET['page'] ) && $this->wc_am_activation_tab_key === $_GET['page'] ) {
+					return;
+				}
+				// Do not show activation notice on staging/development sites.
+				if ( $this->is_staging() ) {
 					return;
 				}
 				?>
@@ -721,7 +721,7 @@ if ( ! class_exists( 'WC_AM_Client_2_12_0' ) ) {
 		 */
 		public function check_external_blocking() {
 
-			// Show a  notice if external requests are blocked through the WP_HTTP_BLOCK_EXTERNAL constant.
+			// Show a notice if external requests are blocked through the WP_HTTP_BLOCK_EXTERNAL constant.
 			if ( defined( 'WP_HTTP_BLOCK_EXTERNAL' ) && WP_HTTP_BLOCK_EXTERNAL === true ) {
 
 				// Check if our API endpoint is in the allowed hosts.

--- a/wc-am-client.php
+++ b/wc-am-client.php
@@ -351,24 +351,26 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 					}
 				}
 
-				foreach ( $staging_subdomains as $staging_pattern ) {
-					if ( substr( $staging_pattern, 0, 1 ) === '*' ) {
-						$needle = substr( $staging_pattern, 2 );
+				if ( ! $this->is_staging ) {
+					foreach ( $staging_subdomains as $staging_pattern ) {
+						if ( substr( $staging_pattern, 0, 1 ) === '*' ) {
+							$needle = substr( $staging_pattern, 2 );
 
-						if ( substr( $host, -strlen( $needle ) ) === $needle ) {
+							if ( substr( $host, -strlen( $needle ) ) === $needle ) {
+								$this->is_staging = true;
+								break;
+							}
+						} elseif ( substr( $staging_pattern, -1 ) === '.' || substr( $staging_pattern, -2 ) === '-.' ) {
+							$trimmed_pattern = rtrim( $staging_pattern, '.' );
+
+							if ( substr( $host, 0, strlen( $trimmed_pattern ) ) === $trimmed_pattern ) {
+								$this->is_staging = true;
+								break;
+							}
+						} elseif ( $host === $staging_pattern ) {
 							$this->is_staging = true;
 							break;
 						}
-					} elseif ( substr( $staging_pattern, -1 ) === '.' || substr( $staging_pattern, -2 ) === '-.' ) {
-						$trimmed_pattern = rtrim( $staging_pattern, '.' );
-
-						if ( substr( $host, 0, strlen( $trimmed_pattern ) ) === $trimmed_pattern ) {
-							$this->is_staging = true;
-							break;
-						}
-					} elseif ( $host === $staging_pattern ) {
-						$this->is_staging = true;
-						break;
 					}
 				}
 			}

--- a/wc-am-client.php
+++ b/wc-am-client.php
@@ -1334,8 +1334,8 @@ if ( ! class_exists( 'WC_AM_Client_2_12_0' ) ) {
 		 */
 		public function send_query( $args ) {
 
-			if ( ! isset( $args['site_url'] ) ) {
-				$args['site_url'] = home_url();
+			if ( ! isset( $args['object'] ) ) {
+				$args['object'] = $this->wc_am_domain ? $this->wc_am_domain : str_replace( array( 'http://', 'https://' ), '', home_url() );
 			}
 
 			$target_url = esc_url_raw( add_query_arg( 'wc-api', 'wc-am-api', $this->api_url ) . '&' . http_build_query( $args ) );

--- a/wc-am-client.php
+++ b/wc-am-client.php
@@ -1371,7 +1371,6 @@ if ( ! class_exists( 'WC_AM_Client_2_12_0' ) ) {
 				'version'           => $this->wc_am_software_version,
 				'product_id'        => $this->product_id,
 				'product_parent_id' => $this->product_parent_id,
-				// API key may be empty on staging sites, which is allowed for updates.
 				'api_key'           => ! empty( $this->data[ $this->wc_am_api_key_key ] ) ? $this->data[ $this->wc_am_api_key_key ] : '',
 				'instance'          => $this->wc_am_instance_id,
 			);

--- a/wc-am-client.php
+++ b/wc-am-client.php
@@ -16,22 +16,22 @@
  *
  * @link https://kestrelwp.com/developers
  *
- * @version     2.11.1
+ * @version     2.12.0
  * @author      Kestrel
- * @copyright   Copyright (c) 2013-2025 Kestrel
+ * @copyright   Copyright (c) 2013-2026 Kestrel
  * @license     http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  * @package     Kestrel API Manager for WooCommerce
  */
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
+if ( ! class_exists( 'WC_AM_Client_2_12_0' ) ) {
 	/**
 	 * API Manager for WooCommerce client class.
 	 *
 	 * @since 1.0.0
 	 */
-	class WC_AM_Client_2_11_1 {
+	class WC_AM_Client_2_12_0 {
 
 		/** @var string API URL. */
 		private $api_url = '';
@@ -147,6 +147,8 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 
 		/**
 		 * Client constructor.
+		 *
+		 * @since 1.0.0
 		 *
 		 * @param string                   $file The main plugin or theme __FILE__ path.
 		 * @param int|null                 $product_id The product ID. If null, it should be provided by the customer in the API settings.
@@ -383,7 +385,7 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 		 *
 		 * Non-scalar values are ignored.
 		 *
-		 * @since 2.9
+		 * @since 2.9.0
 		 *
 		 * @param string|array $item Data to sanitize.
 		 * @return string|array
@@ -399,7 +401,7 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 		/**
 		 * Register a menu or submenu specific to this product.
 		 *
-		 * @updated 2.9
+		 * @return void
 		 */
 		public function register_menu() {
 
@@ -427,7 +429,9 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 		/**
 		 *  Tries auto updates.
 		 *
-		 * @since 2.8
+		 * @since 2.8.0
+		 *
+		 * @return void
 		 */
 		public function try_automatic_updates() {
 			global $wp_version;
@@ -444,7 +448,7 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 		/**
 		 * Tries to set auto updates.
 		 *
-		 * @since 2.8
+		 * @since 2.8.0
 		 *
 		 * @param bool|null $update Whether to update.
 		 * @param object    $item   The item to update.
@@ -476,7 +480,7 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 		/**
 		 * Checks if auto updates are disabled.
 		 *
-		 * @since 2.8
+		 * @since 2.8.0
 		 *
 		 * @return bool
 		 */
@@ -518,9 +522,9 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 		 *
 		 * Plugin updates stored in 'auto_update_plugins' array.
 		 *
-		 * @see   'wp-admin/includes/class-wp-plugins-list-table.php'
+		 * @see `wp-admin/includes/class-wp-plugins-list-table.php`
 		 *
-		 * @since 2.8
+		 * @since 2.8.0
 		 *
 		 * @param string $html        HTML of the auto-update message.
 		 * @param string $plugin_file Plugin file.
@@ -591,6 +595,8 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 
 		/**
 		 * Generate the default data.
+		 *
+		 * @reurn void
 		 */
 		public function activation() {
 			$instance_exists = get_option( $this->wc_am_instance_key );
@@ -653,6 +659,8 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 
 		/**
 		 * Deactivates the license on the API server.
+		 *
+		 * @Since 1.0.0
 		 */
 		public function license_key_deactivation() {
 			$activation_status = get_option( $this->wc_am_activated_key );
@@ -671,8 +679,11 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 
 		/**
 		 * Displays an inactive notice when the software is inactive.
+		 *
+		 * @return void
 		 */
 		public function inactive_notice() {
+
 			/**
 			 * Filters the inactive notice.
 			 *
@@ -685,6 +696,10 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 			 */
 			if ( apply_filters( 'wc_am_client_inactive_notice_override', true ) ) {
 				if ( ! current_user_can( 'manage_options' ) ) {
+					return;
+				}
+				// Do not show activation notice on staging/development sites.
+				if ( $this->is_staging() ) {
 					return;
 				}
 				// phpcs:ignore
@@ -701,6 +716,8 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 
 		/**
 		 * Check for external blocking contstant.
+		 *
+		 * @return void
 		 */
 		public function check_external_blocking() {
 
@@ -1283,6 +1300,8 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 
 		/**
 		 * Check for software updates.
+		 *
+		 * @return void
 		 */
 		public function check_for_update() {
 			$this->plugin_name = $this->wc_am_plugin_name;
@@ -1314,6 +1333,11 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 		 * @return bool|string $response
 		 */
 		public function send_query( $args ) {
+
+			// Always include the site URL for staging verification on the licensing server.
+			if ( ! isset( $args['site_url'] ) ) {
+				$args['site_url'] = home_url();
+			}
 
 			$target_url = esc_url_raw( add_query_arg( 'wc-api', 'wc-am-api', $this->api_url ) . '&' . http_build_query( $args ) );
 			$request    = wp_safe_remote_post( $target_url, array( 'timeout' => 15 ) );
@@ -1348,6 +1372,7 @@ if ( ! class_exists( 'WC_AM_Client_2_11_1' ) ) {
 				'version'           => $this->wc_am_software_version,
 				'product_id'        => $this->product_id,
 				'product_parent_id' => $this->product_parent_id,
+				// API key may be empty on staging sites, which is allowed for updates.
 				'api_key'           => ! empty( $this->data[ $this->wc_am_api_key_key ] ) ? $this->data[ $this->wc_am_api_key_key ] : '',
 				'instance'          => $this->wc_am_instance_id,
 			);

--- a/wc-am-client.php
+++ b/wc-am-client.php
@@ -1334,7 +1334,6 @@ if ( ! class_exists( 'WC_AM_Client_2_12_0' ) ) {
 		 */
 		public function send_query( $args ) {
 
-			// Always include the site URL for staging verification on the licensing server.
 			if ( ! isset( $args['site_url'] ) ) {
 				$args['site_url'] = home_url();
 			}

--- a/wc-am-client.php
+++ b/wc-am-client.php
@@ -1334,7 +1334,7 @@ if ( ! class_exists( 'WC_AM_Client_2_12_0' ) ) {
 		 */
 		public function send_query( $args ) {
 
-			if ( ! isset( $args['object'] ) ) {
+			if ( empty( $args['object'] ) ) {
 				$args['object'] = $this->wc_am_domain ? $this->wc_am_domain : str_replace( array( 'http://', 'https://' ), '', home_url() );
 			}
 


### PR DESCRIPTION
## Summary

This PR will include detection of a staging/local/development website to suppress license prompt. The new version will also make sure to send the site url to process API requests. The newer versions of API manager will be able to determine whether the requesting plugin/theme can receive update w/o activation if on a staging site, as well allow activating without counting the activation against the total number of activations.

See [SC-7483](https://app.shortcut.com/kestrel/story/7483)